### PR TITLE
Remove duplicate fields from Flatpak manifest.

### DIFF
--- a/org.guitarix.Guitarix.json
+++ b/org.guitarix.Guitarix.json
@@ -70,7 +70,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2",
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2",
                     "sha256": "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402"
                 }
             ]

--- a/org.guitarix.Guitarix.json
+++ b/org.guitarix.Guitarix.json
@@ -60,14 +60,12 @@
             "cleanup": [
                 "/include",
                 "/lib/cmake",
-                "*.a"
+                "*.a",
+                "*.so"
             ],
             "build-commands": [
                 "./bootstrap.sh --with-libraries=system,iostreams",
                 "./b2 install variant=release link=shared runtime-link=shared --prefix=/app -j $FLATPAK_BUILDER_N_JOBS"
-            ],
-            "cleanup": [
-                "*.so"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Some fields were duplicated in the modules of the
Flatpak manifest.

@hfiguiere please have a look :eyes: 