### PR TITLE
Metainfo cleanup

### DIFF
--- a/org.guitarix.Guitarix.metainfo.xml
+++ b/org.guitarix.Guitarix.metainfo.xml
@@ -7,22 +7,21 @@
  <summary>A virtual guitar amplifier</summary>
  <description>
    <p>
-     Guitarix is a virtual guitar amplifier for Linux running on Jack
-     Audio Connection Kit.
+     Guitarix is a virtual guitar amplifier for Linux running on Jack Audio
+     Connection Kit.
    </p>
    <p>
-     Guitarix takes the signal from your guitar as any real amp would
-     do: as a mono-signal from your sound card. The input is processed
-     by a main amp and a rack-section. Both can be routed separately
-     and deliver a processed stereo-signal via Jack. You may fill the
-     rack with effects from more than 25 built-in modules including
-     stuff from a simple noise gate to brain-slashing modulation f/x
-     like flanger, phaser or auto-wah.
+     Guitarix takes the signal from your guitar as any real amp would do: as a
+     mono-signal from your sound card. The input is processed by a main amp
+     and a rack-section. Both can be routed separately and deliver a processed
+     stereo-signal via Jack. You may fill the rack with effects from more than
+     25 built-in modules including stuff from a simple noise gate to
+     brain-slashing modulation f/x like flanger, phaser or auto-wah.
    </p>
    <p>
-     Your signal is processed with minimum latency. On any properly
-     set-up Linux-system you don't have to wait more than 10ms until
-     your sound is processed by guitarix.
+     Your signal is processed with minimum latency. On any properly set-up
+     Linux-system you don't have to wait more than 10ms until your sound is
+     processed by guitarix.
    </p>
  </description>
  <content_rating type="oars-1.1" />
@@ -71,9 +70,11 @@
      <description>
        <ul>
          <li>Add Slovak translation by Jozef Riha</li>
-         <li>Fix issue #104 lv2 plugins contains executable stack, patch by Alexander Tsoy</li>
+         <li>Fix issue #104 lv2 plugins contains executable stack, patch by
+         Alexander Tsoy</li>
          <li>Fix issue #105 Compile error on 0.40.0</li>
-         <li>Fix issue #109 cannot initialize a variable of type 'char ' with an rvalue of type 'void '</li>
+         <li>Fix issue #109 cannot initialize a variable of type 'char ' with
+         an rvalue of type 'void '</li>
          <li>Fix issue #110 error: unknown type name 'va_list'</li>
          <li>Add NSM support</li>
          <li>Add midi out for tuner</li>
@@ -81,7 +82,8 @@
          <li>GxTuner set to use same precision then the tuner in guitarix</li>
          <li>Use tab-box for LV2 plugs with to much controls</li>
          <li>Disable GxVibe, because it is broken</li>
-         <li>Fix several Bug's and hopefully don't introduce to much new one's</li>
+         <li>Fix several Bug's and hopefully don't introduce to much new
+         one's</li>
        </ul>
      </description>
    </release>
@@ -92,10 +94,34 @@
          <li>Port LV2 plugin GUIs to X11/cairo</li>
          <li>Add Midi feedback support</li>
          <li>Add new PowerAmp module</li>
-         <li>Fix several Bug's and hopefully don't introduce to much new ones</li>
+         <li>Fix several Bug's and hopefully don't introduce to much new
+         ones</li>
        </ul>
      </description>
    </release>
-   <release version="0.39.0" date="2020-01-14" />
+   <release version="0.39.0" date="2020-01-14">
+     <description>
+       <p>A virtual guitar amplifier for Linux running with jack (Jack Audio
+       Connection Kit).</p>
+       <p>This is a maintenance release which mainly is meant to get rid of
+       the python2 build dependency.</p>
+       <p>Changes are so far:</p>
+       <ul>
+         <li>Updated waf version to 2.0.19 by Andreas Degert</li>
+         <li>Cleanup all GTK(mm) calls to be able to build with -DGSEAL_ENABLE
+         flag (prepare to update to GTK3) by Hubert Figuière</li>
+         <li>Update Russian Translation by Valeriy Shtobbe and Olesya
+         Gerasimenko (Basealt Translation Team)</li>
+         <li>Bind lv2:enabled to guitarix on_off switch and remove from UI by
+         Hermann Meyer</li>
+         <li>Update all build scripts to use faust version 2.15.11 by Hermann
+         Meyer</li>
+         <li>Add new option -E --hideonquit, to make the UI experience smooth
+         when used as LV2 plugin (via Carla export) by Hermann Meyer</li>
+         <li>Add exit handler and warning when sample-rate is above 96kHz by
+         Hermann Meyer</li>
+       </ul>
+     </description>
+   </release>
  </releases>
 </component>


### PR DESCRIPTION
1. Make sure that all versions have release notes.
2. The number of characters per line should be maximum 80
for the entire file.